### PR TITLE
Add a little helper dom builder class and use it

### DIFF
--- a/lib/dom_builder.rb
+++ b/lib/dom_builder.rb
@@ -1,0 +1,22 @@
+module DomBuilder
+
+  def table
+    content_tag(:table, &Proc.new)
+  end
+
+  def tr
+    content_tag(:tr, &Proc.new)
+  end
+
+  def td
+    content_tag(:td, &Proc.new)
+  end
+
+  def content_tag(tag_name)
+    "<#{tag_name}>" +
+      (yield if block_given?).to_s +
+      "</#{tag_name}>"
+  end
+
+end
+


### PR DESCRIPTION
- New DomBuilder class which has table, tr, and td methods
- refactor the table building with these methods (to avoid extra empty 'tr' rows in the output
- fix a couple bad end anchor tags (another dom cleanup)

Just for kicks, i ran DOM Monster and PageSpeed on this - assuming this app would make those tools say "WAY TO GO".  DOM Monster reported a bunch of empty dom elements.  Turns out the `join('<tr/>')` was adding an extra row between each row.  You probably meant `join('</tr>')` but even that wouldn't quite work because the last entry would not get a close tag.

It was silly fun but I wrote the tiniest DSL for rendering html as a string.  good nerd times.
